### PR TITLE
[Add] #21 implement IsRangeRotatable property

### DIFF
--- a/Assets/Scripts/AI.cs
+++ b/Assets/Scripts/AI.cs
@@ -198,7 +198,7 @@ public class AI : MonoBehaviour
 		{
 			// atode kaeru
 			// 指定したAttackの攻撃範囲に当たる攻撃範囲のマスを全て列挙する
-			Floors.AddRange(_map.GetFloorsByDistance(enemyUnit.Floor, unit.Attacks[0].RangeMin, unit.Attacks[0].RangeMax)
+			Floors.AddRange(_map.GetFloorsByDistance(enemyUnit.Floor, ((SingleAttack)unit.Attacks[0]).RangeMin, ((SingleAttack)unit.Attacks[0]).RangeMax)
 				.Where(f => _mc.GetFloorCost(f) < _mc.MaxLimitCost));
 		}
 		return Floors.Distinct().ToArray();

--- a/Assets/Scripts/AI.cs
+++ b/Assets/Scripts/AI.cs
@@ -198,7 +198,7 @@ public class AI : MonoBehaviour
 		{
 			// atode kaeru
 			// 指定したAttackの攻撃範囲に当たる攻撃範囲のマスを全て列挙する
-			Floors.AddRange(_map.GetFloorsByDistance(enemyUnit.Floor, ((SingleAttack)unit.Attacks[0]).RangeMin, ((SingleAttack)unit.Attacks[0]).RangeMax)
+			Floors.AddRange(_map.GetFloorsByDistance(enemyUnit.Floor, unit.Attacks[0].RangeMin, unit.Attacks[0].RangeMax)
 				.Where(f => _mc.GetFloorCost(f) < _mc.MaxLimitCost));
 		}
 		return Floors.Distinct().ToArray();

--- a/Assets/Scripts/Attack.cs
+++ b/Assets/Scripts/Attack.cs
@@ -34,7 +34,10 @@ public abstract class Attack : MonoBehaviour
 		new Vector2Int(-1, 0),
 		new Vector2Int(0, -1)
 	};
-	public List<Vector2Int> Range{ get { return _range; } }
+	public List<Vector2Int> Range
+	{
+		get { return _range; }
+	}
 }
 
 

--- a/Assets/Scripts/Attack.cs
+++ b/Assets/Scripts/Attack.cs
@@ -3,21 +3,9 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
-public class Attack : MonoBehaviour
+public abstract class Attack : MonoBehaviour
 {
-    public enum TargetingKind
-    {
-        Single,
-        Range
-    }
-
-    [SerializeField]
-    private TargetingKind _targetingWay;
-    public TargetingKind TargetingWay
-    {
-        get { return _targetingWay; }
-    }
-
+	// 攻撃の種類
     [SerializeField]
 	private Type _type;
 	public Type Type
@@ -25,14 +13,7 @@ public class Attack : MonoBehaviour
 		get { return _type; }
 	}
 
-    // 攻撃範囲を回転させられるかどうか
-    [SerializeField]
-    private bool _isRangeRotatable;
-    public bool IsRangeRotatable
-    {
-        get { return _isRangeRotatable; }
-    }
-
+	// 攻撃力
 	[SerializeField]
 	private int _power;
 	public int Power
@@ -40,7 +21,11 @@ public class Attack : MonoBehaviour
 		get { return _power; }
 	}
 
-	// atode kottini ikou shitai.
+	/// <summary>
+	/// 攻撃範囲.
+	/// SingleAttackの場合は、攻撃"可能"なマスの集合を示します。
+	/// RangeAttackの場合は、攻撃"する"マスの集合を示します。
+	/// </summary>
 	[SerializeField]
 	private List<Vector2Int> _range = new List<Vector2Int>
 	{
@@ -49,12 +34,13 @@ public class Attack : MonoBehaviour
 		new Vector2Int(-1, 0),
 		new Vector2Int(0, -1)
 	};
+	public List<Vector2Int> Range{ get { return _range; } }
+}
 
-	public List<Vector2Int> Range
-	{
-		get { return _range; }
-	}
 
+public class SingleAttack : Attack
+{
+	// 攻撃先の最小距離
 	[SerializeField]
 	private int _rangeMin;
 	public int RangeMin
@@ -62,10 +48,24 @@ public class Attack : MonoBehaviour
 		get { return _rangeMin; }
 	}
 
+	// 攻撃先の最大距離
 	[SerializeField]
 	private int _rangeMax;
 	public int RangeMax
 	{
 		get { return _rangeMax; }
 	}
+}
+
+
+public class RangeAttack : Attack
+{
+	// 攻撃範囲を回転させられるかどうか
+	[SerializeField]
+	private bool _isRotatable;
+	public bool IsRotatable
+	{
+		get { return _isRotatable; }
+	}
+
 }

--- a/Assets/Scripts/Attack.cs
+++ b/Assets/Scripts/Attack.cs
@@ -6,7 +6,7 @@ using UnityEngine.UI;
 public abstract class Attack : MonoBehaviour
 {
 	// 攻撃の種類
-    [SerializeField]
+	[SerializeField]
 	private Type _type;
 	public Type Type
 	{

--- a/Assets/Scripts/Attack.cs
+++ b/Assets/Scripts/Attack.cs
@@ -10,6 +10,7 @@ public class Attack : MonoBehaviour
         Single,
         Range
     }
+
     [SerializeField]
     private TargetingKind _targetingWay;
     public TargetingKind TargetingWay
@@ -23,6 +24,14 @@ public class Attack : MonoBehaviour
 	{
 		get { return _type; }
 	}
+
+    // 攻撃範囲を回転させられるかどうか
+    [SerializeField]
+    private bool _isRangeRotatable;
+    public bool IsRangeRotatable
+    {
+        get { return _isRangeRotatable; }
+    }
 
 	[SerializeField]
 	private int _power;
@@ -40,6 +49,7 @@ public class Attack : MonoBehaviour
 		new Vector2Int(-1, 0),
 		new Vector2Int(0, -1)
 	};
+
 	public List<Vector2Int> Range
 	{
 		get { return _range; }

--- a/Assets/Scripts/Attack.cs
+++ b/Assets/Scripts/Attack.cs
@@ -7,7 +7,7 @@ public abstract class Attack : MonoBehaviour
 {
 	// 攻撃の種類
 	[SerializeField]
-	private Type _type;
+	protected Type _type;
 	public Type Type
 	{
 		get { return _type; }
@@ -15,7 +15,7 @@ public abstract class Attack : MonoBehaviour
 	
 	// 攻撃力
 	[SerializeField]
-	private int _power;
+	protected int _power;
 	public int Power
 	{
 		get { return _power; }
@@ -27,7 +27,7 @@ public abstract class Attack : MonoBehaviour
 	/// RangeAttackの場合は、攻撃"する"マスの集合を示します。
 	/// </summary>
 	[SerializeField]
-	private List<Vector2Int> _range = new List<Vector2Int>
+	protected List<Vector2Int> _range = new List<Vector2Int>
 	{
 		new Vector2Int(0, 1),
 		new Vector2Int(1, 0),

--- a/Assets/Scripts/AttackController.cs
+++ b/Assets/Scripts/AttackController.cs
@@ -169,7 +169,7 @@ public class AttackController : MonoBehaviour
     /// <summary>
     /// マウスの位置が変更されているときに、攻撃可能ハイライト位置を変える
     /// </summary>
-    public int UpdateAttackableHighLight(Map map, Unit attacker, Attack attack, int befDir)
+    public int UpdateAttackableHighLight(Map map, Unit attacker, RangeAttack attack, int befDir)
     {
         int nowDir = GetMouseDirFromUnit(attacker);
         if (nowDir == befDir) return befDir;
@@ -185,7 +185,7 @@ public class AttackController : MonoBehaviour
     ///<summary>
     ///攻撃可能ハイライトを初期設定する
     /// </summary>
-    public int InitializeAttackableHighLight(Map map, Unit attacker, Attack attack)
+    public int InitializeAttackableHighLight(Map map, Unit attacker, RangeAttack attack)
     {
         return UpdateAttackableHighLight(map, attacker, attack, -1);
     }
@@ -193,7 +193,7 @@ public class AttackController : MonoBehaviour
     /// <summary>
     /// 攻撃可能範囲を取得する（Set2で使用するためにUnit保管）
     /// </summary>
-    public List<Vector2Int> GetAttackRanges(Map map,Unit unit,Attack attack,int dir)
+    public List<Vector2Int> GetAttackRanges(Map map,Unit unit, RangeAttack attack,int dir)
     {
         // GetAttackableRangesを使いまわすと、外部が使用すべき関数が見えにくくなるため、新しく作成
         return GetAttackableRanges(map, unit, attack, dir);

--- a/Assets/Scripts/Map.cs
+++ b/Assets/Scripts/Map.cs
@@ -99,7 +99,7 @@ public class Map : MonoBehaviour
 	/// <summary>
 	/// 攻撃可能なマスをハイライトし, 攻撃対象がいるか否かを返すメソッド
 	/// </summary>
-	public bool HighlightAttackableFloors(Floor startFloor, Attack attack)
+	public bool HighlightAttackableFloors(Floor startFloor, SingleAttack attack)
 	{
 		var hasTarget = false;
 		foreach(var Floor in GetFloorsByDistance(startFloor, attack.RangeMin, attack.RangeMax))


### PR DESCRIPTION
範囲攻撃における攻撃可能範囲を、回転させられるかを示すプロパティの追加の一例
（回転させられない攻撃があるため、追加しています）。
単体攻撃の場合は不要なプロパティのため、その点が変な実装となっています。

TargetingKind(攻撃範囲指定)において、

- Single //1体攻撃
- RangeRot     //範囲攻撃(回転可能)
- RangeConst //範囲攻撃(回転不可能)

とする手法も考えましたが、その場合はAttackControllerで範囲攻撃の実装が煩雑になるため難しい所です。