### PR TITLE
[Fix] Fixed Floor name format exception.

### DIFF
--- a/Assets/Scripts/Floor.cs
+++ b/Assets/Scripts/Floor.cs
@@ -120,27 +120,25 @@ public class Floor : MonoBehaviour
 	/// <returns></returns>
 	private Vector2Int ParseLocalCoordinateFromName()
 	{
-		if (Regex.IsMatch(transform.name, @"^\(\d+, \d+\)$"))
+		// パターンにマッチしない座標であれば, 警告し終了する.
+		if(!Regex.IsMatch(transform.name, @"^\(\d+, \d+\)$"))
 		{
-			string[] coors = transform.name.Split(new string[] { "(", ",", " ", "　", ")" }, StringSplitOptions.RemoveEmptyEntries);
-			return new Vector2Int(int.Parse(coors[0]), int.Parse(coors[1]));
-		}
-		else
-		{
-			Debug.LogWarning("Floor Name Format Exception");
-			Debug.LogWarning(tranform.name);
+			Debug.LogWarning("[Error] Floor Name Format (Coordinate) Exception : " + transform.name);
 			Application.Quit();
 		}
+
+		string[] coors = transform.name.Split(new string[] { "(", ",", " ", "　", ")" }, StringSplitOptions.RemoveEmptyEntries);
+		return new Vector2Int(int.Parse(coors[0]), int.Parse(coors[1]));
 	}
 
 
-    /// <summary>
-    /// 初期化メソッド
-    /// </summary>
-    /// <param name="map"></param>
-    /// <param name="units"></param>
-    /// <param name="mc"></param>
-    public void Initialize(Map map, Units units, MoveController mc)
+	/// <summary>
+	/// 初期化メソッド
+	/// </summary>
+	/// <param name="map"></param>
+	/// <param name="units"></param>
+	/// <param name="mc"></param>
+	public void Initialize(Map map, Units units, MoveController mc)
 	{
 		_map = map;
 		_units = units;


### PR DESCRIPTION
close #3 
(↑意味ないかもしれんけど一応)

最後のCommit、

https://github.com/at0x0ft/SRPG2018/blob/2cb5c9b81983e43ec853701733882335794636d1/Assets/Scripts/Floor.cs#L128-L133

では, この部分が値を返さないという理由でIntelliSenseに怒られた.
また,130行目が, "tranform.name" ("s"がない)になっていた.

そこでスペルの修正と, パターンにマッチしないをif文で条件分岐するように書き換えた.

レビューお願いします.