### PR TITLE
[Fix] debug_enemys_highlight

### DIFF
--- a/Assets/Scripts/BoardController.cs
+++ b/Assets/Scripts/BoardController.cs
@@ -60,7 +60,7 @@ public class BoardController : MonoBehaviour
 		var ac = new AttackController(_map, _units, _damageCalculator);
 		_map.Initilize(this, _moveController, _units, _ui);
 		_units.Initilize(_map, _moveController, ac);
-		_ui.Initialize(_units, ac);
+		_ui.Initialize(_units, ac, _map);
 
 
 		// endCommandボタンが押下されたらmapインスタンスメソッドの持つNextSet()を実行

--- a/Assets/Scripts/SubWindows/AttackSelectWindow.cs
+++ b/Assets/Scripts/SubWindows/AttackSelectWindow.cs
@@ -14,12 +14,14 @@ public class AttackSelectWindow : SubWindow
 	private AttackInfoWindow _attackInfoWindow;
 	private AttackController _attackController;
 	private Units _units;
+	private Map _map;
 
-	public void Initialize(Units units, AttackController attackController, AttackInfoWindow attackInfoWindow)
+	public void Initialize(Units units, AttackController attackController, AttackInfoWindow attackInfoWindow, Map map)
 	{
 		_attackInfoWindow = attackInfoWindow;
 		_attackController = attackController;
 		_units = units;
+		_map = map;
 	}
 
 	/// <summary>
@@ -64,6 +66,7 @@ public class AttackSelectWindow : SubWindow
 			_attackBtns[i].gameObject.SetActive(canAttack);
 			_attackBtns[i].GetComponentInChildren<Text>().text = atk.name;
 			_attackBtns[i].onClick.AddListener(() => _attackInfoWindow.Show(atk));
+			_attackBtns[i].onClick.AddListener(() => _map.ClearHighlight());
 			_attackBtns[i].onClick.AddListener(() => _attackController.Highlight(_units.ActiveUnit, atk));
 		}
 

--- a/Assets/Scripts/UI.cs
+++ b/Assets/Scripts/UI.cs
@@ -57,9 +57,9 @@ public class UI : MonoBehaviour
 		get{ return _attackSelectWindow; }
 	}
 
-	public void Initialize(Units units, AttackController ac)
+	public void Initialize(Units units, AttackController ac, Map _map)
 	{
-		_attackSelectWindow.Initialize(units, ac, _attackInfoWindow);
+		_attackSelectWindow.Initialize(units, ac, _attackInfoWindow, _map);
 	}
 
 	/// <summary>


### PR DESCRIPTION
バグの原因は、攻撃コマンドを選択するときにハイライトを消し忘れていたことでした。
そこでMapクラスをAttackSelectWindowに保持させ、選択毎にハイライト削除を行いました。

close #48 