### PR TITLE
[feat] Update movecost and damage adjust rates

### DIFF
--- a/Assets/Scenes/3vs3.unity
+++ b/Assets/Scenes/3vs3.unity
@@ -41884,26 +41884,26 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 941ddeb2092bea54e8760b25f7d61490, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _strongRate: 1.2
-  _slightlyStrongRate: 1.1
+  _strongRate: 1.5
+  _slightlyStrongRate: 1.2
   _normalRate: 1
-  _slightlyWeakRate: 0.9
-  _weakRate: 0.8
-  _normalReduceRate: 0.2
+  _slightlyWeakRate: 0.8
+  _weakRate: 0.5
+  _normalReduceRate: 0
   _forestReduceRate: 0
   _rockReduceRate: 0.5
-  _normalAvoidRate: 10
-  _forestAvoidRate: 20
+  _normalAvoidRate: 0
+  _forestAvoidRate: 15
   _rockAvoidRate: 0
-  _goodAtRate: 1.1
+  _goodAtRate: 1.2
   _notSoGoodOrBadAtRate: 1
-  _badAtRate: 0.9
+  _badAtRate: 0.8
   _strongCriticalRate: 0
   _slightlyStrongCriticalRate: 0
   _normalCriticalRate: 3
   _slightlyWeakCriticalRate: 5
   _weakCriticalRate: 7
-  _criticalDamageRate: 2
+  _criticalDamageRate: 3
 --- !u!1 &1413038980
 GameObject:
   m_ObjectHideFlags: 0
@@ -58716,12 +58716,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _moveSpeed: 1.5
-  _forwardMaxMoveAmount: 7
-  _middleMaxMoveAmount: 5
-  _backMaxMoveAmount: 3
+  _forwardMaxMoveAmount: 14
+  _middleMaxMoveAmount: 10
+  _backMaxMoveAmount: 6
   _normalCost: 1
-  _forestCost: 2
-  _rockCost: 3
+  _rockCost: 2
+  _forestCost: 3
   _maxLimitCost: 999
 --- !u!1 &1971427510
 GameObject:

--- a/Assets/Scenes/Chapter1/Chapter1Battle.unity
+++ b/Assets/Scenes/Chapter1/Chapter1Battle.unity
@@ -41919,26 +41919,26 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 941ddeb2092bea54e8760b25f7d61490, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _strongRate: 1.2
-  _slightlyStrongRate: 1.1
+  _strongRate: 1.5
+  _slightlyStrongRate: 1.2
   _normalRate: 1
-  _slightlyWeakRate: 0.9
-  _weakRate: 0.8
-  _normalReduceRate: 0.2
+  _slightlyWeakRate: 0.8
+  _weakRate: 0.5
+  _normalReduceRate: 0
   _forestReduceRate: 0
   _rockReduceRate: 0.5
-  _normalAvoidRate: 10
-  _forestAvoidRate: 20
+  _normalAvoidRate: 0
+  _forestAvoidRate: 15
   _rockAvoidRate: 0
-  _goodAtRate: 1.1
+  _goodAtRate: 1.2
   _notSoGoodOrBadAtRate: 1
-  _badAtRate: 0.9
+  _badAtRate: 0.8
   _strongCriticalRate: 0
   _slightlyStrongCriticalRate: 0
   _normalCriticalRate: 3
   _slightlyWeakCriticalRate: 5
   _weakCriticalRate: 7
-  _criticalDamageRate: 2
+  _criticalDamageRate: 3
 --- !u!1 &1415167462
 GameObject:
   m_ObjectHideFlags: 0
@@ -58376,12 +58376,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _moveSpeed: 1.5
-  _forwardMaxMoveAmount: 7
-  _middleMaxMoveAmount: 5
-  _backMaxMoveAmount: 3
+  _forwardMaxMoveAmount: 14
+  _middleMaxMoveAmount: 10
+  _backMaxMoveAmount: 6
   _normalCost: 1
-  _forestCost: 2
-  _rockCost: 3
+  _rockCost: 2
+  _forestCost: 3
   _maxLimitCost: 999
 --- !u!1 &1967782461
 GameObject:

--- a/Assets/Scenes/Test.unity
+++ b/Assets/Scenes/Test.unity
@@ -41919,26 +41919,26 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 941ddeb2092bea54e8760b25f7d61490, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _strongRate: 1.2
-  _slightlyStrongRate: 1.1
+  _strongRate: 1.5
+  _slightlyStrongRate: 1.2
   _normalRate: 1
-  _slightlyWeakRate: 0.9
-  _weakRate: 0.8
-  _normalReduceRate: 0.2
+  _slightlyWeakRate: 0.8
+  _weakRate: 0.5
+  _normalReduceRate: 0
   _forestReduceRate: 0
   _rockReduceRate: 0.5
-  _normalAvoidRate: 10
-  _forestAvoidRate: 20
+  _normalAvoidRate: 0
+  _forestAvoidRate: 15
   _rockAvoidRate: 0
-  _goodAtRate: 1.1
+  _goodAtRate: 1.2
   _notSoGoodOrBadAtRate: 1
-  _badAtRate: 0.9
+  _badAtRate: 0.8
   _strongCriticalRate: 0
   _slightlyStrongCriticalRate: 0
   _normalCriticalRate: 3
   _slightlyWeakCriticalRate: 5
   _weakCriticalRate: 7
-  _criticalDamageRate: 2
+  _criticalDamageRate: 3
 --- !u!1 &1415167462
 GameObject:
   m_ObjectHideFlags: 0
@@ -58376,12 +58376,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _moveSpeed: 1.5
-  _forwardMaxMoveAmount: 7
-  _middleMaxMoveAmount: 5
-  _backMaxMoveAmount: 3
+  _forwardMaxMoveAmount: 14
+  _middleMaxMoveAmount: 10
+  _backMaxMoveAmount: 6
   _normalCost: 1
-  _forestCost: 2
-  _rockCost: 3
+  _rockCost: 2
+  _forestCost: 3
   _maxLimitCost: 999
 --- !u!1 &1967782461
 GameObject:

--- a/Assets/Scripts/Attacks/DamageCalculator.cs
+++ b/Assets/Scripts/Attacks/DamageCalculator.cs
@@ -193,14 +193,17 @@ public class DamageCalculator : MonoBehaviour
 		// 取り敢えず, 暫定的にダメージ計算時に命中可否の判定を行うこととする. (命中可否を画面に通知するかどうかは, また別で考える)
 		if(!IsHit(attack, defenderFloor)) return null;
 
+		// 相性補正に対して, クリティカル補正の判定 (クリティカルになったかどうかを通知するかどうかは, また別で考える)
+		float attackTypeAdvantageRate =
+			IsCritical(attack, defender)
+			? 3.0f
+			: GetATypeAdvantageRate(attack.AType, defender.AType);
+
 		// ダメージ = { (攻撃力 * attackの威力 * 相性補正 * 得意補正) / (防御力 * 地形効果防御補正) } * 乱数
 		var damage = Mathf.RoundToInt(
-			(attacker.AttackPower * attack.Power * GetATypeAdvantageRate(attack.AType, defender.AType) * GetGoodAtRate(attack.AType, attacker.AType))
+			(attacker.AttackPower * attack.Power * attackTypeAdvantageRate * GetGoodAtRate(attack.AType, attacker.AType))
 			/ (defender.Defence * (1f + GetReduceRate(defenderFloor)))
 			* Random.Range(0.85f, 1f));
-
-		// クリティカル補正の判定 (クリティカルになったかどうかを通知するかどうかは, また別で考える)
-		if(IsCritical(attack, defender)) damage = Mathf.RoundToInt(damage * _criticalDamageRate);
 
 		return damage;
 	}

--- a/Assets/Scripts/Attacks/DamageCalculator.cs
+++ b/Assets/Scripts/Attacks/DamageCalculator.cs
@@ -7,39 +7,39 @@ public class DamageCalculator : MonoBehaviour
 
 	// === 相性補正 ===
 	[SerializeField]
-	private float _strongRate = 1.2f;
+	private float _strongRate = 1.5f;
 	[SerializeField]
-	private float _slightlyStrongRate = 1.1f;
+	private float _slightlyStrongRate = 1.2f;
 	[SerializeField]
 	private float _normalRate = 1f;
 	[SerializeField]
-	private float _slightlyWeakRate = 0.9f;
+	private float _slightlyWeakRate = 0.8f;
 	[SerializeField]
-	private float _weakRate = 0.8f;
+	private float _weakRate = 0.5f;
 
 	// === 地形効果防御補正 ===
 	[SerializeField]
-	private float _normalReduceRate = 0;
+	private float _normalReduceRate = 0f;
 	[SerializeField]
-	private float _forestReduceRate = 0.2f;
+	private float _forestReduceRate = 0f;
 	[SerializeField]
 	private float _rockReduceRate = 0.5f;
 
 	// === 地形効果命中補正 ===
 	[SerializeField]
-	private int _normalAvoidRate = 20;
+	private int _normalAvoidRate = 0;
 	[SerializeField]
-	private int _forestAvoidRate = 10;
+	private int _forestAvoidRate = 15;
 	[SerializeField]
 	private int _rockAvoidRate = 0;
 
 	// === 得意補正 ===
 	[SerializeField]
-	private float _goodAtRate = 1.1f;
+	private float _goodAtRate = 1.2f;
 	[SerializeField]
 	private float _notSoGoodOrBadAtRate = 1f;
 	[SerializeField]
-	private float _badAtRate = 0.9f;
+	private float _badAtRate = 0.8f;
 
 	// === クリティカル補正 ===
 	[SerializeField]
@@ -53,7 +53,7 @@ public class DamageCalculator : MonoBehaviour
 	[SerializeField]
 	private int _weakCriticalRate = 7;
 	[SerializeField]
-	private float _criticalDamageRate = 2f;
+	private float _criticalDamageRate = 3f;
 
 
 	// ==========関数==========

--- a/Assets/Scripts/MoveController.cs
+++ b/Assets/Scripts/MoveController.cs
@@ -12,18 +12,18 @@ public class MoveController : MonoBehaviour
 	private float _moveSpeed = 1.5f;
 
 	[SerializeField]
-	private int _forwardMaxMoveAmount = 7;
+	private int _forwardMaxMoveAmount = 14;
 	[SerializeField]
-	private int _middleMaxMoveAmount = 5;
+	private int _middleMaxMoveAmount = 10;
 	[SerializeField]
-	private int _backMaxMoveAmount = 3;
+	private int _backMaxMoveAmount = 6;
 
 	[SerializeField]
 	private int _normalCost = 1;
 	[SerializeField]
-	private int _forestCost = 2;
+	private int _rockCost = 2;
 	[SerializeField]
-	private int _rockCost = 3;
+	private int _forestCost = 3;
 
 	[SerializeField]
 	private int _maxLimitCost = 999;


### PR DESCRIPTION
取り敢えず,

<移動コスト系>
森林の移動コスト: 2 -> 3
岩場の移動コスト: 2 -> 3
前衛中衛後衛の持っている移動コスト: (2倍に)

<床の特殊効果系> (ダメージ軽減率/回避上昇率の順で表記)
草原: 0%/0%
岩場: 50%/0%
森林: 0%/15%

<ダメージ補正>
有利: 1.2 -> 1.5倍
不利: 0.8 -> 0.5倍
やや有利: 1.1 -> 1.2倍
やや不利: 0.9 -> 0.8倍
得意補正: 1.1 -> 1.2倍
不得意補正: 0.9 -> 0.8倍
クリティカルダメージ倍率: 2 -> 3倍

と修正しました.
各キャラの体力等の細かい調整はまた後ほど別branchで行うこととして, 倍率に関してこれに異議等があれば指摘いただけるとありがたいです.

Close #173 